### PR TITLE
Added library.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,23 @@
+{
+  "name": "GCodeParser",
+  "version": "1.3.0",
+  "description": "The GCodeParser library is a lightweight G-Code parser for the Arduino using only a single character buffer to first collect a line of code (also called a 'block') from a serial or file input and then parse that line into a code block and comments.",
+  "keywords": "device, control",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/tgolla/GCodeParser"
+  },
+  "authors":
+  [
+    {
+      "name": "Terence F. Golla",
+      "email": "tfg@terencegolla.com",
+      "maintainer": true
+    }
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/tgolla/GCodeParser",
+  "frameworks": "*",
+  "platforms": "*"
+}


### PR DESCRIPTION
As described in https://docs.platformio.org/en/latest/librarymanager/creating.html, added library.json

When trying to use the library, I noticed it's only marked as arduino in pio and thus doesn't compile with esp-idf. As far as I can tell, it doesn't need any arduino lib specific things, just standard libraries. Thus added it, so everyone can use the lib (otherwise PIO will not include the library)

Hope I didn't forget anything

Best, Lena